### PR TITLE
Use env vars for SFTP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # pleyadaapp
+
+## Configuration
+
+The application expects SFTP connection details to be provided via environment variables:
+
+- `SFTP_HOST` - address of the SFTP server
+- `SFTP_PORT` - port to connect (defaults to `22`)
+- `SFTP_USERNAME` - username for login
+- `SFTP_PASSWORD` - password for login
+- `SFTP_REMOTE_PATH` - remote path for file operations (defaults to `/`)
+
+When running with `docker-compose`, set these variables in an `.env` file or export
+them in your shell before starting the stack:
+
+```bash
+SFTP_HOST=example.com
+SFTP_USERNAME=user
+SFTP_PASSWORD=secret
+SFTP_REMOTE_PATH=/uploads
+SFTP_PORT=2222 docker-compose up
+```

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,6 @@
+sftp:
+  host: ${SFTP_HOST:}
+  port: ${SFTP_PORT:22}
+  username: ${SFTP_USERNAME:}
+  password: ${SFTP_PASSWORD:}
+  remote_path: ${SFTP_REMOTE_PATH:/}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    image: myapp:latest
+    environment:
+      SFTP_HOST: ${SFTP_HOST}
+      SFTP_PORT: ${SFTP_PORT:-22}
+      SFTP_USERNAME: ${SFTP_USERNAME}
+      SFTP_PASSWORD: ${SFTP_PASSWORD}
+      SFTP_REMOTE_PATH: ${SFTP_REMOTE_PATH:-/}


### PR DESCRIPTION
## Summary
- configure SFTP settings in `application.yml` using environment variables
- pass the same variables through `docker-compose.yml`
- document the available variables in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ac027dc688328907ae184a6396018